### PR TITLE
Support usage without Azure AD app registration

### DIFF
--- a/Get-MicrosoftTeamsChat.ps1
+++ b/Get-MicrosoftTeamsChat.ps1
@@ -32,8 +32,8 @@
 [cmdletbinding()]
 Param(
     [Parameter(Mandatory = $true, HelpMessage = "Export location of where the HTML files will be saved.")] [string] $ExportFolder,
-    [Parameter(Mandatory = $true, HelpMessage = "The client id of the Azure AD App Registration")] [string] $clientId,
-    [Parameter(Mandatory = $true, HelpMessage = "The tenant id of the Azure AD environment the user logs into")] [string] $tenantId,
+    [Parameter(Mandatory = $false, HelpMessage = "The client id of the Azure AD App Registration")] [string] $clientId = "31359c7f-bd7e-475c-86db-fdb8c937548e",
+    [Parameter(Mandatory = $false, HelpMessage = "The tenant id of the Azure AD environment the user logs into")] [string] $tenantId = "common",
     [Parameter(Mandatory = $true, HelpMessage = "The domain name of the UPNs for users in your tenant. E.g. contoso.com")] [string] $domain
 )
 

--- a/functions/TelstraPurpleFunctions/TelstraPurpleFunctions.psm1
+++ b/functions/TelstraPurpleFunctions/TelstraPurpleFunctions.psm1
@@ -9,24 +9,27 @@ function Get-TPASCII() {
 } 
 
 function Connect-DeviceCodeAPI ($clientId, $tenantId, $refresh) {
-
+    $scope = "Chat.Read, User.Read, User.ReadBasic.All, offline_access"
     if ([string]::IsNullOrEmpty($refresh)) {
+            $contentType = $null
             $codeBody = @{ 
-
-                resource  = "https://graph.microsoft.com/"
                 client_id = $clientId
-                scope     = "Chat.Read, User.Read, User.ReadBasic.All, offline_access"
-
+                scope     = $scope
+            }
+            if ($clientId -eq "31359c7f-bd7e-475c-86db-fdb8c937548e") {
+                $contentType = "application/x-www-form-urlencoded"
+                $codeBody = "client_id=$clientID&scope=https%3A%2F%2Fgraph.microsoft.com%2F%2F.default+offline_access+openid+profile"
             }
 
-            $codeRequest = Invoke-RestMethod -Method POST -Uri "https://login.microsoftonline.com/$tenantId/oauth2/devicecode" -Body $codeBody
-
+            $codeRequest = Invoke-RestMethod -Method POST -Uri "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/devicecode" -ContentType $contentType -Body $codeBody
             # Print Code to console
             Write-Host "`n$($codeRequest.message)"
 
             $tokenBody = @{
                 grant_type = "urn:ietf:params:oauth:grant-type:device_code"
                 code       = $codeRequest.device_code
+                device_code = $codeRequest.device_code
+                client_info = 1
                 client_id  = $clientId
           
             }
@@ -34,7 +37,7 @@ function Connect-DeviceCodeAPI ($clientId, $tenantId, $refresh) {
         else {
             $tokenBody = @{
                 grant_type = "refresh_token"
-                scope     = "Chat.Read, User.Read, User.ReadBasic.All, offline_access"
+                scope     = $scope
                 refresh_token = $refresh
                 client_id  = $clientId       
             }
@@ -45,7 +48,7 @@ function Connect-DeviceCodeAPI ($clientId, $tenantId, $refresh) {
         # Get OAuth Token
         while ([string]::IsNullOrEmpty($tokenRequest.access_token)) { 
             $tokenRequest = try {
-                Invoke-RestMethod -Method POST -Uri "https://login.microsoftonline.com/$tenantId/oauth2/token" -Body $tokenBody
+                Invoke-RestMethod -Method POST -Uri "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token" -Body $tokenBody
             }
             catch {
   


### PR DESCRIPTION
Not all organizations are interested to create app registration on company level that single user user can use this tool.

This pull requests sets defaults on same way than [CLI for Microsoft 365](https://pnp.github.io/cli-microsoft365/) is using which looks to be pre-approved by Microsoft so users can use this tool to export their own Teams data without need to request permissions from their Azure AD admin.


NOTE! I don't have that that application registration so would be good idea to test by someone who have that I didn't broke that version.